### PR TITLE
Add sequel pro importer info to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Official pages: [Medium](http://medium.com/@huyphams), [Facebook](http://faceboo
 
 Author: huy@tableplus.com
 
+Need to import Sequel Pro connections? Check out [TP Importer](https://github.com/brandonjjon/tp-importer)
 
 App screenshots:
 


### PR DESCRIPTION
This tool has been useful to some people so I thought it would be helpful to the community to make it more discoverable.

Thanks!