### PR TITLE
Update README.md - fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ App screenshots:
 
 ![Welcome-screen](https://github.com/TablePlus/TablePlus/blob/master/Resources/welcome-screen.png "Welcome screen")
 ![Workspace-screen](https://github.com/TablePlus/TablePlus/blob/master/Resources/workspace-light.png "Workspace")
-![Dark-Theme-screen](https://github.com/TablePlus/TablePlus/blob/master/Resources/workspace-dark.png "Dark Them screen")
+![Dark-Theme-screen](https://github.com/TablePlus/TablePlus/blob/master/Resources/workspace-dark.png "Dark Theme screen")
 
 TablePlus is free and has no limit on trial time, but I'd be very happy if you purchased a license to support development.
 


### PR DESCRIPTION
Fix a typo in the README for Dark Theme Screenshot title attribute.